### PR TITLE
fix: Stack loading

### DIFF
--- a/src/components/Stack.svelte
+++ b/src/components/Stack.svelte
@@ -12,6 +12,7 @@
   export let link;
 
   function isEmpty(object) {
+    if(object == null || undefined) return true;
     if(JSON.stringify(object) == JSON.stringify({})) return true;
     return false;
   }


### PR DESCRIPTION
 Due to my old way to checking if an object was invalid, objects with null or undefinied values would attempt to be displayed, throwing an error

Resolves: #18